### PR TITLE
New york1 solid

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.HelloWorld">
-        <activity android:name="ayds.newyork.songinfo.home.view.HomeViewActivity">
+        <activity android:name="ayds.newyork.songinfo.home.view.HomeViewActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/HomeModelInjector.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/HomeModelInjector.kt
@@ -18,7 +18,7 @@ object HomeModelInjector {
 
     fun initHomeModel(homeView: HomeView) {
         val spotifyLocalStorage: SpotifyLocalStorage = SpotifyLocalStorageImpl(
-          homeView as Context, CursorToSpotifySongMapperImpl()
+            homeView as Context, CursorToSpotifySongMapperImpl()
         )
         val spotifyTrackService: SpotifyTrackService = SpotifyInjector.spotifyTrackService
 

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/entities/SpotifySong.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/entities/SpotifySong.kt
@@ -6,6 +6,7 @@ interface Song {
     val artistName: String
     val albumName: String
     val releaseDate: String
+    val releaseDatePrecision:String
     val spotifyUrl: String
     val imageUrl: String
     var isLocallyStored: Boolean
@@ -17,6 +18,7 @@ data class SpotifySong(
   override val artistName: String,
   override val albumName: String,
   override val releaseDate: String,
+  override val releaseDatePrecision:String,
   override val spotifyUrl: String,
   override val imageUrl: String,
   override var isLocallyStored: Boolean = false
@@ -31,7 +33,7 @@ object EmptySong : Song {
     override val artistName: String = ""
     override val albumName: String = ""
     override val releaseDate: String = ""
+    override val releaseDatePrecision: String=""
     override val spotifyUrl: String = ""
     override val imageUrl: String = ""
     override var isLocallyStored: Boolean = false
-}

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/entities/SpotifySong.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/entities/SpotifySong.kt
@@ -22,10 +22,7 @@ data class SpotifySong(
   override val spotifyUrl: String,
   override val imageUrl: String,
   override var isLocallyStored: Boolean = false
-) : Song {
-
-    val year: String = releaseDate.split("-").first()
-}
+) : Song 
 
 object EmptySong : Song {
     override val id: String = ""
@@ -33,7 +30,8 @@ object EmptySong : Song {
     override val artistName: String = ""
     override val albumName: String = ""
     override val releaseDate: String = ""
-    override val releaseDatePrecision: String=""
+    override val releaseDatePrecision: String = ""
     override val spotifyUrl: String = ""
     override val imageUrl: String = ""
     override var isLocallyStored: Boolean = false
+}

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/entities/SpotifySong.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/entities/SpotifySong.kt
@@ -6,23 +6,23 @@ interface Song {
     val artistName: String
     val albumName: String
     val releaseDate: String
-    val releaseDatePrecision:String
+    val releaseDatePrecision: String
     val spotifyUrl: String
     val imageUrl: String
     var isLocallyStored: Boolean
 }
 
 data class SpotifySong(
-  override val id: String,
-  override val songName: String,
-  override val artistName: String,
-  override val albumName: String,
-  override val releaseDate: String,
-  override val releaseDatePrecision:String,
-  override val spotifyUrl: String,
-  override val imageUrl: String,
-  override var isLocallyStored: Boolean = false
-) : Song 
+    override val id: String,
+    override val songName: String,
+    override val artistName: String,
+    override val albumName: String,
+    override val releaseDate: String,
+    override val releaseDatePrecision: String,
+    override val spotifyUrl: String,
+    override val imageUrl: String,
+    override var isLocallyStored: Boolean = false
+) : Song
 
 object EmptySong : Song {
     override val id: String = ""

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/entities/SpotifySong.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/entities/SpotifySong.kt
@@ -1,12 +1,16 @@
 package ayds.newyork.songinfo.home.model.entities
 
+enum class DatePrecision {
+    YEAR, MONTH, DAY
+}
+
 interface Song {
     val id: String
     val songName: String
     val artistName: String
     val albumName: String
     val releaseDate: String
-    val releaseDatePrecision: String
+    val releaseDatePrecision: DatePrecision
     val spotifyUrl: String
     val imageUrl: String
     var isLocallyStored: Boolean
@@ -18,7 +22,7 @@ data class SpotifySong(
     override val artistName: String,
     override val albumName: String,
     override val releaseDate: String,
-    override val releaseDatePrecision: String,
+    override val releaseDatePrecision: DatePrecision,
     override val spotifyUrl: String,
     override val imageUrl: String,
     override var isLocallyStored: Boolean = false
@@ -30,7 +34,7 @@ object EmptySong : Song {
     override val artistName: String = ""
     override val albumName: String = ""
     override val releaseDate: String = ""
-    override val releaseDatePrecision: String = ""
+    override val releaseDatePrecision: DatePrecision = DatePrecision.DAY
     override val spotifyUrl: String = ""
     override val imageUrl: String = ""
     override var isLocallyStored: Boolean = false

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/ReleaseDateHelper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/ReleaseDateHelper.kt
@@ -1,0 +1,19 @@
+package ayds.newyork.songinfo.home.model.repository.external.spotify.tracks
+
+import ayds.newyork.songinfo.home.model.entities.DatePrecision
+
+interface ReleaseDateHelper {
+    fun getReleaseDatePrecisionAsEnum(releaseDatePrecision: String):DatePrecision
+}
+
+internal class ReleaseDateHelperImpl:ReleaseDateHelper{
+
+    override fun getReleaseDatePrecisionAsEnum(releaseDatePrecision: String):DatePrecision {
+        return when(releaseDatePrecision){
+            "day" -> DatePrecision.DAY
+            "month" -> DatePrecision.MONTH
+            "year" -> DatePrecision.YEAR
+            else -> throw Exception()
+        }
+    }
+}

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
@@ -72,7 +72,8 @@ internal class JsonToSongResolver(
 
     private fun JsonObject.getReleaseDatePrecision(): DatePrecision {
         val album = this[ALBUM].asJsonObject
-        return releaseDateHelper.getReleaseDatePrecisionAsEnum(album[RELEASE_DATE_PRECISION].asString)
+        val releaseDate=album[RELEASE_DATE_PRECISION].asString
+        return releaseDateHelper.getReleaseDatePrecisionAsEnum(releaseDate)
     }
 
     private fun JsonObject.getImageUrl(): String {

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
@@ -1,5 +1,6 @@
 package ayds.newyork.songinfo.home.model.repository.external.spotify.tracks
 
+import ayds.newyork.songinfo.home.model.entities.DatePrecision
 import com.google.gson.Gson
 import ayds.newyork.songinfo.home.model.entities.SpotifySong
 import com.google.gson.JsonObject
@@ -26,16 +27,18 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
     override fun getSongFromExternalData(serviceData: String?): SpotifySong? =
         try {
             serviceData?.getFirstItem()?.let { item ->
-                SpotifySong(
-                    item.getId(),
-                    item.getSongName(),
-                    item.getArtistName(),
-                    item.getAlbumName(),
-                    item.getReleaseDate(),
-                    item.getReleaseDatePrecision(),
-                    item.getSpotifyUrl(),
-                    item.getImageUrl()
-                )
+                item.getReleaseDatePrecision()?.let {
+                    SpotifySong(
+                        item.getId(),
+                        item.getSongName(),
+                        item.getArtistName(),
+                        item.getAlbumName(),
+                        item.getReleaseDate(),
+                        it,
+                        item.getSpotifyUrl(),
+                        item.getImageUrl()
+                    )
+                }
             }
         } catch (e: Exception) {
             null
@@ -67,10 +70,18 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
         return album[RELEASE_DATE].asString
     }
 
-    private fun JsonObject.getReleaseDatePrecision(): String {
+    private fun JsonObject.getReleaseDatePrecision(): DatePrecision? {
         val album = this[ALBUM].asJsonObject
-        return album[RELEASE_DATE_PRECISION].asString
+        return getReleaseDatePrecisionAsEnum(album[RELEASE_DATE_PRECISION].asString)
     }
+
+    private fun getReleaseDatePrecisionAsEnum(releaseDatePrecision: String) =
+        when(releaseDatePrecision){
+            "day" -> DatePrecision.DAY
+            "month" -> DatePrecision.MONTH
+            "year" -> DatePrecision.YEAR
+            else -> null
+        }
 
     private fun JsonObject.getImageUrl(): String {
         val album = this[ALBUM].asJsonObject

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
@@ -26,20 +26,18 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
 
     override fun getSongFromExternalData(serviceData: String?): SpotifySong? =
         try {
-            serviceData?.getFirstItem()?.let { item ->
-                item.getReleaseDatePrecision()?.let {
+            serviceData?.getFirstItem()?.let {  item ->
                     SpotifySong(
                         item.getId(),
                         item.getSongName(),
                         item.getArtistName(),
                         item.getAlbumName(),
                         item.getReleaseDate(),
-                        it,
+                        item.getReleaseDatePrecision(),
                         item.getSpotifyUrl(),
                         item.getImageUrl()
                     )
                 }
-            }
         } catch (e: Exception) {
             null
         }
@@ -70,7 +68,7 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
         return album[RELEASE_DATE].asString
     }
 
-    private fun JsonObject.getReleaseDatePrecision(): DatePrecision? {
+    private fun JsonObject.getReleaseDatePrecision(): DatePrecision {
         val album = this[ALBUM].asJsonObject
         return getReleaseDatePrecisionAsEnum(album[RELEASE_DATE_PRECISION].asString)
     }
@@ -80,7 +78,7 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
             "day" -> DatePrecision.DAY
             "month" -> DatePrecision.MONTH
             "year" -> DatePrecision.YEAR
-            else -> null
+            else -> throw Exception()
         }
 
     private fun JsonObject.getImageUrl(): String {

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
@@ -16,6 +16,7 @@ private const val ARTISTS = "artists"
 private const val ALBUM = "album"
 private const val IMAGES = "images"
 private const val RELEASE_DATE = "release_date"
+private const val RELEASE_DATE_PRECISION="release_date_precision"
 private const val URL = "url"
 private const val EXTERNAL_URL = "external_urls"
 private const val SPOTIFY = "spotify"
@@ -27,7 +28,7 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
             serviceData?.getFirstItem()?.let { item ->
                 SpotifySong(
                     item.getId(), item.getSongName(), item.getArtistName(), item.getAlbumName(),
-                    item.getReleaseDate(), item.getSpotifyUrl(), item.getImageUrl()
+                    item.getReleaseDate(),item.getReleaseDatePrecision(), item.getSpotifyUrl(), item.getImageUrl()
                 )
             }
         } catch (e: Exception) {
@@ -60,6 +61,11 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
         return album[RELEASE_DATE].asString
     }
 
+    private fun JsonObject.getReleaseDatePrecision(): String {
+        val album = this[ALBUM].asJsonObject
+        return album[RELEASE_DATE_PRECISION].asString
+    }
+
     private fun JsonObject.getImageUrl(): String {
         val album = this[ALBUM].asJsonObject
         return album[IMAGES].asJsonArray[1].asJsonObject[URL].asString
@@ -69,5 +75,7 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
         val externalUrl = this[EXTERNAL_URL].asJsonObject
         return externalUrl[SPOTIFY].asString
     }
+
+
 
 }

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
@@ -22,7 +22,9 @@ private const val URL = "url"
 private const val EXTERNAL_URL = "external_urls"
 private const val SPOTIFY = "spotify"
 
-internal class JsonToSongResolver : SpotifyToSongResolver {
+internal class JsonToSongResolver(
+    private val releaseDateHelper:ReleaseDateHelper
+) : SpotifyToSongResolver {
 
     override fun getSongFromExternalData(serviceData: String?): SpotifySong? =
         try {
@@ -70,16 +72,8 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
 
     private fun JsonObject.getReleaseDatePrecision(): DatePrecision {
         val album = this[ALBUM].asJsonObject
-        return getReleaseDatePrecisionAsEnum(album[RELEASE_DATE_PRECISION].asString)
+        return releaseDateHelper.getReleaseDatePrecisionAsEnum(album[RELEASE_DATE_PRECISION].asString)
     }
-
-    private fun getReleaseDatePrecisionAsEnum(releaseDatePrecision: String) =
-        when(releaseDatePrecision){
-            "day" -> DatePrecision.DAY
-            "month" -> DatePrecision.MONTH
-            "year" -> DatePrecision.YEAR
-            else -> throw Exception()
-        }
 
     private fun JsonObject.getImageUrl(): String {
         val album = this[ALBUM].asJsonObject

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyToSongResolver.kt
@@ -16,7 +16,7 @@ private const val ARTISTS = "artists"
 private const val ALBUM = "album"
 private const val IMAGES = "images"
 private const val RELEASE_DATE = "release_date"
-private const val RELEASE_DATE_PRECISION="release_date_precision"
+private const val RELEASE_DATE_PRECISION = "release_date_precision"
 private const val URL = "url"
 private const val EXTERNAL_URL = "external_urls"
 private const val SPOTIFY = "spotify"
@@ -27,8 +27,14 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
         try {
             serviceData?.getFirstItem()?.let { item ->
                 SpotifySong(
-                    item.getId(), item.getSongName(), item.getArtistName(), item.getAlbumName(),
-                    item.getReleaseDate(),item.getReleaseDatePrecision(), item.getSpotifyUrl(), item.getImageUrl()
+                    item.getId(),
+                    item.getSongName(),
+                    item.getArtistName(),
+                    item.getAlbumName(),
+                    item.getReleaseDate(),
+                    item.getReleaseDatePrecision(),
+                    item.getSpotifyUrl(),
+                    item.getImageUrl()
                 )
             }
         } catch (e: Exception) {
@@ -75,7 +81,6 @@ internal class JsonToSongResolver : SpotifyToSongResolver {
         val externalUrl = this[EXTERNAL_URL].asJsonObject
         return externalUrl[SPOTIFY].asString
     }
-
 
 
 }

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyTrackInjector.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/external/spotify/tracks/SpotifyTrackInjector.kt
@@ -13,7 +13,9 @@ object SpotifyTrackInjector {
         .addConverterFactory(ScalarsConverterFactory.create())
         .build()
     private val spotifyTrackAPI = spotifyAPIRetrofit.create(SpotifyTrackAPI::class.java)
-    private val spotifyToSongResolver: SpotifyToSongResolver = JsonToSongResolver()
+    private val releaseDateHelper: ReleaseDateHelper=ReleaseDateHelperImpl()
+    private val spotifyToSongResolver: SpotifyToSongResolver = JsonToSongResolver(releaseDateHelper)
+
 
 
     val spotifyTrackService: SpotifyTrackService = SpotifyTrackServiceImpl(

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
@@ -21,6 +21,7 @@ internal class CursorToSpotifySongMapperImpl : CursorToSpotifySongMapper {
                       artistName = getString(getColumnIndexOrThrow(ARTIST_COLUMN)),
                       albumName = getString(getColumnIndexOrThrow(ALBUM_COLUMN)),
                       releaseDate = getString(getColumnIndexOrThrow(RELEASE_DATE_COLUMN)),
+                      releaseDatePrecision = getString(getColumnIndexOrThrow(RELEASE_DATE_PRECISION_COLUMN)),
                       spotifyUrl = getString(getColumnIndexOrThrow(SPOTIFY_URL_COLUMN)),
                       imageUrl = getString(getColumnIndexOrThrow(IMAGE_URL_COLUMN)),
                     )

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
@@ -4,7 +4,6 @@ import android.database.Cursor
 import ayds.newyork.songinfo.home.model.entities.DatePrecision
 import ayds.newyork.songinfo.home.model.entities.SpotifySong
 import java.sql.SQLException
-import java.util.*
 
 interface CursorToSpotifySongMapper {
 

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
@@ -1,8 +1,10 @@
 package ayds.newyork.songinfo.home.model.repository.local.spotify.sqldb
 
 import android.database.Cursor
+import ayds.newyork.songinfo.home.model.entities.DatePrecision
 import ayds.newyork.songinfo.home.model.entities.SpotifySong
 import java.sql.SQLException
+import java.util.*
 
 interface CursorToSpotifySongMapper {
 
@@ -21,10 +23,12 @@ internal class CursorToSpotifySongMapperImpl : CursorToSpotifySongMapper {
                         artistName = getString(getColumnIndexOrThrow(ARTIST_COLUMN)),
                         albumName = getString(getColumnIndexOrThrow(ALBUM_COLUMN)),
                         releaseDate = getString(getColumnIndexOrThrow(RELEASE_DATE_COLUMN)),
-                        releaseDatePrecision = getString(
-                            getColumnIndexOrThrow(
-                                RELEASE_DATE_PRECISION_COLUMN
-                            )
+                        releaseDatePrecision = DatePrecision.valueOf(
+                            getString(
+                                getColumnIndexOrThrow(
+                                    RELEASE_DATE_PRECISION_COLUMN
+                                )
+                            ).uppercase(Locale.getDefault())
                         ),
                         spotifyUrl = getString(getColumnIndexOrThrow(SPOTIFY_URL_COLUMN)),
                         imageUrl = getString(getColumnIndexOrThrow(IMAGE_URL_COLUMN)),

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
@@ -17,19 +17,15 @@ internal class CursorToSpotifySongMapperImpl : CursorToSpotifySongMapper {
         try {
             with(cursor) {
                 if (moveToNext()) {
+                    val storedPrecisionOrdinal = cursor.getInt(getColumnIndexOrThrow(RELEASE_DATE_PRECISION_COLUMN))
+                    val releaseDatePrecision = DatePrecision.values()[storedPrecisionOrdinal]
                     SpotifySong(
                         id = getString(getColumnIndexOrThrow(ID_COLUMN)),
                         songName = getString(getColumnIndexOrThrow(NAME_COLUMN)),
                         artistName = getString(getColumnIndexOrThrow(ARTIST_COLUMN)),
                         albumName = getString(getColumnIndexOrThrow(ALBUM_COLUMN)),
                         releaseDate = getString(getColumnIndexOrThrow(RELEASE_DATE_COLUMN)),
-                        releaseDatePrecision = DatePrecision.valueOf(
-                            getString(
-                                getColumnIndexOrThrow(
-                                    RELEASE_DATE_PRECISION_COLUMN
-                                )
-                            ).uppercase(Locale.getDefault())
-                        ),
+                        releaseDatePrecision = releaseDatePrecision,
                         spotifyUrl = getString(getColumnIndexOrThrow(SPOTIFY_URL_COLUMN)),
                         imageUrl = getString(getColumnIndexOrThrow(IMAGE_URL_COLUMN)),
                     )

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/CursorToSpotifySongMapper.kt
@@ -16,14 +16,18 @@ internal class CursorToSpotifySongMapperImpl : CursorToSpotifySongMapper {
             with(cursor) {
                 if (moveToNext()) {
                     SpotifySong(
-                      id = getString(getColumnIndexOrThrow(ID_COLUMN)),
-                      songName = getString(getColumnIndexOrThrow(NAME_COLUMN)),
-                      artistName = getString(getColumnIndexOrThrow(ARTIST_COLUMN)),
-                      albumName = getString(getColumnIndexOrThrow(ALBUM_COLUMN)),
-                      releaseDate = getString(getColumnIndexOrThrow(RELEASE_DATE_COLUMN)),
-                      releaseDatePrecision = getString(getColumnIndexOrThrow(RELEASE_DATE_PRECISION_COLUMN)),
-                      spotifyUrl = getString(getColumnIndexOrThrow(SPOTIFY_URL_COLUMN)),
-                      imageUrl = getString(getColumnIndexOrThrow(IMAGE_URL_COLUMN)),
+                        id = getString(getColumnIndexOrThrow(ID_COLUMN)),
+                        songName = getString(getColumnIndexOrThrow(NAME_COLUMN)),
+                        artistName = getString(getColumnIndexOrThrow(ARTIST_COLUMN)),
+                        albumName = getString(getColumnIndexOrThrow(ALBUM_COLUMN)),
+                        releaseDate = getString(getColumnIndexOrThrow(RELEASE_DATE_COLUMN)),
+                        releaseDatePrecision = getString(
+                            getColumnIndexOrThrow(
+                                RELEASE_DATE_PRECISION_COLUMN
+                            )
+                        ),
+                        spotifyUrl = getString(getColumnIndexOrThrow(SPOTIFY_URL_COLUMN)),
+                        imageUrl = getString(getColumnIndexOrThrow(IMAGE_URL_COLUMN)),
                     )
                 } else {
                     null

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyLocalStorageImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyLocalStorageImpl.kt
@@ -54,7 +54,7 @@ internal class SpotifyLocalStorageImpl(
             put(ARTIST_COLUMN, song.artistName)
             put(ALBUM_COLUMN, song.albumName)
             put(RELEASE_DATE_COLUMN, song.releaseDate)
-            put(RELEASE_DATE_PRECISION_COLUMN, song.releaseDatePrecision)
+            put(RELEASE_DATE_PRECISION_COLUMN, song.releaseDatePrecision.name)
             put(SPOTIFY_URL_COLUMN, song.spotifyUrl)
             put(IMAGE_URL_COLUMN, song.imageUrl)
         }

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyLocalStorageImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyLocalStorageImpl.kt
@@ -54,7 +54,7 @@ internal class SpotifyLocalStorageImpl(
             put(ARTIST_COLUMN, song.artistName)
             put(ALBUM_COLUMN, song.albumName)
             put(RELEASE_DATE_COLUMN, song.releaseDate)
-            put(RELEASE_DATE_PRECISION_COLUMN,song.releaseDatePrecision)
+            put(RELEASE_DATE_PRECISION_COLUMN, song.releaseDatePrecision)
             put(SPOTIFY_URL_COLUMN, song.spotifyUrl)
             put(IMAGE_URL_COLUMN, song.imageUrl)
         }

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyLocalStorageImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyLocalStorageImpl.kt
@@ -23,6 +23,7 @@ internal class SpotifyLocalStorageImpl(
         ALBUM_COLUMN,
         ALBUM_COLUMN,
         RELEASE_DATE_COLUMN,
+        RELEASE_DATE_PRECISION_COLUMN,
         SPOTIFY_URL_COLUMN,
         IMAGE_URL_COLUMN
     )
@@ -53,6 +54,7 @@ internal class SpotifyLocalStorageImpl(
             put(ARTIST_COLUMN, song.artistName)
             put(ALBUM_COLUMN, song.albumName)
             put(RELEASE_DATE_COLUMN, song.releaseDate)
+            put(RELEASE_DATE_PRECISION_COLUMN,song.releaseDatePrecision)
             put(SPOTIFY_URL_COLUMN, song.spotifyUrl)
             put(IMAGE_URL_COLUMN, song.imageUrl)
         }

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyLocalStorageImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyLocalStorageImpl.kt
@@ -54,7 +54,7 @@ internal class SpotifyLocalStorageImpl(
             put(ARTIST_COLUMN, song.artistName)
             put(ALBUM_COLUMN, song.albumName)
             put(RELEASE_DATE_COLUMN, song.releaseDate)
-            put(RELEASE_DATE_PRECISION_COLUMN, song.releaseDatePrecision.name)
+            put(RELEASE_DATE_PRECISION_COLUMN, song.releaseDatePrecision.ordinal)
             put(SPOTIFY_URL_COLUMN, song.spotifyUrl)
             put(IMAGE_URL_COLUMN, song.imageUrl)
         }

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyTableConstants.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyTableConstants.kt
@@ -19,6 +19,6 @@ const val createSongsTableQuery: String =
             "$ARTIST_COLUMN integer, " +
             "$ALBUM_COLUMN string, " +
             "$RELEASE_DATE_COLUMN string, " +
-            "$RELEASE_DATE_PRECISION_COLUMN string, " +
+            "$RELEASE_DATE_PRECISION_COLUMN integer, " +
             "$SPOTIFY_URL_COLUMN string, " +
             "$IMAGE_URL_COLUMN string)"

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyTableConstants.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyTableConstants.kt
@@ -7,6 +7,7 @@ const val NAME_COLUMN = "name"
 const val ARTIST_COLUMN = "artist"
 const val ALBUM_COLUMN = "album"
 const val RELEASE_DATE_COLUMN = "release_date"
+const val RELEASE_DATE_PRECISION_COLUMN="release_date_precision"
 const val SPOTIFY_URL_COLUMN = "spotify_url"
 const val IMAGE_URL_COLUMN = "image_url"
 
@@ -18,5 +19,6 @@ const val createSongsTableQuery: String =
             "$ARTIST_COLUMN integer, " +
             "$ALBUM_COLUMN string, " +
             "$RELEASE_DATE_COLUMN string, " +
+            "$RELEASE_DATE_PRECISION_COLUMN string, " +
             "$SPOTIFY_URL_COLUMN string, " +
             "$IMAGE_URL_COLUMN string)"

--- a/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyTableConstants.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/model/repository/local/spotify/sqldb/SpotifyTableConstants.kt
@@ -7,7 +7,7 @@ const val NAME_COLUMN = "name"
 const val ARTIST_COLUMN = "artist"
 const val ALBUM_COLUMN = "album"
 const val RELEASE_DATE_COLUMN = "release_date"
-const val RELEASE_DATE_PRECISION_COLUMN="release_date_precision"
+const val RELEASE_DATE_PRECISION_COLUMN = "release_date_precision"
 const val SPOTIFY_URL_COLUMN = "spotify_url"
 const val IMAGE_URL_COLUMN = "image_url"
 

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/HomeViewInjector.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/HomeViewInjector.kt
@@ -5,7 +5,8 @@ import ayds.newyork.songinfo.home.model.HomeModelInjector
 
 object HomeViewInjector {
 
-    val songDescriptionHelper: SongDescriptionHelper = SongDescriptionHelperImpl()
+    val releaseDateMapper: ReleaseDateMapper = ReleaseDateMapperImpl()
+    val songDescriptionHelper: SongDescriptionHelper = SongDescriptionHelperImpl(releaseDateMapper)
 
     fun init(homeView: HomeView) {
         HomeModelInjector.initHomeModel(homeView)

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/HomeViewInjector.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/HomeViewInjector.kt
@@ -5,7 +5,7 @@ import ayds.newyork.songinfo.home.model.HomeModelInjector
 
 object HomeViewInjector {
 
-    val releaseDateMapper: ReleaseDateMapper = ReleaseDateMapperImpl()
+    private val releaseDateMapper: ReleaseDateMapper = ReleaseDateMapperImpl()
     val songDescriptionHelper: SongDescriptionHelper = SongDescriptionHelperImpl(releaseDateMapper)
 
     fun init(homeView: HomeView) {

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -29,8 +29,9 @@ private fun getReleaseDatePrecisionDay(releaseDate: String): String {
 
 private fun getReleaseDatePrecisionMonth(releaseDate: String): String {
     val separator = ","
-    val month = DateFormatSymbols().months[((releaseDate.split("-")[1])).toInt()]
-    val year = (releaseDate.split("-")[0])
+    val releaseDateArray= releaseDate.split("-").toTypedArray()
+    val month = DateFormatSymbols().months[((releaseDateArray[1])).toInt()]
+    val year = releaseDateArray[0]
     return "$month$separator $year"
 
 }

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -3,27 +3,37 @@ package ayds.newyork.songinfo.home.view
 import ayds.newyork.songinfo.home.model.entities.Song
 
 interface ReleaseDateMapper {
-    fun ReleaseDatePrecision(song: Song): String
+    fun releaseDatePrecision(song: Song): String
 }
 
 internal class ReleaseDateMapperImpl : ReleaseDateMapper {
-    override fun ReleaseDatePrecision(song: Song): String =
+    override fun releaseDatePrecision(song: Song): String =
         when (song.releaseDatePrecision) {
-            "day" -> ReleaseDatePrecisionDay()
-            "month" -> ReleaseDatePrecisionMonth()
-            "year" -> ReleaseDatePrecisionYear()
+            "day" -> releaseDatePrecisionDay()
+            "month" -> releaseDatePrecisionMonth()
+            "year" -> releaseDatePrecisionYear(song)
             else -> "error"
         }
 }
 
-private fun ReleaseDatePrecisionDay(): String {
+private fun releaseDatePrecisionDay(): String {
     return "TODO"
 }
 
-private fun ReleaseDatePrecisionMonth(): String {
+private fun releaseDatePrecisionMonth(): String {
     return "TODO"
 }
 
-private fun ReleaseDatePrecisionYear(): String {
-    return "TODO"
+private fun releaseDatePrecisionYear(song: Song): String {
+    return try {
+        val year: Int = song.releaseDate.toInt()
+        val leap = if (year.isALeapYear()) "a leap year" else "not a leap year"
+
+        "$year $leap"
+    } catch (e: NumberFormatException) {
+        "format error"
+    }
 }
+
+fun Int.isALeapYear() = (this % 4 == 0) && (this % 100 != 0 || this % 400 == 0)
+

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -18,11 +18,15 @@ internal class ReleaseDateMapperImpl : ReleaseDateMapper {
 }
 
 private fun releaseDatePrecisionDay(song: Song): String {
-    return (song.releaseDate.split("-")[2])+"/"+(song.releaseDate.split("-")[1])+"/"+(song.releaseDate.split("-").first())
+    return (song.releaseDate.split("-")[2]) + "/" + (song.releaseDate.split("-")[1]) + "/" + (song.releaseDate.split(
+        "-"
+    ).first())
 }
 
 private fun releaseDatePrecisionMonth(song: Song): String {
-    return DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]+", "+(song.releaseDate.split("-").first())
+    return DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()] + ", " + (song.releaseDate.split(
+        "-"
+    ).first())
 }
 
 private fun releaseDatePrecisionYear(song: Song): String {

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -42,7 +42,7 @@ private fun getReleaseDatePrecisionYear(releaseDate: String): String {
 
         "$year $leap"
     } catch (e: NumberFormatException) {
-        "format error"
+        throw e
     }
 }
 

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -1,6 +1,7 @@
 package ayds.newyork.songinfo.home.view
 
 import ayds.newyork.songinfo.home.model.entities.Song
+import java.text.DateFormatSymbols
 
 interface ReleaseDateMapper {
     fun releaseDatePrecision(song: Song): String
@@ -9,19 +10,19 @@ interface ReleaseDateMapper {
 internal class ReleaseDateMapperImpl : ReleaseDateMapper {
     override fun releaseDatePrecision(song: Song): String =
         when (song.releaseDatePrecision) {
-            "day" -> releaseDatePrecisionDay()
-            "month" -> releaseDatePrecisionMonth()
+            "day" -> releaseDatePrecisionDay(song)
+            "month" -> releaseDatePrecisionMonth(song)
             "year" -> releaseDatePrecisionYear(song)
             else -> "error"
         }
 }
 
-private fun releaseDatePrecisionDay(): String {
-    return "TODO"
+private fun releaseDatePrecisionDay(song: Song): String {
+    return (song.releaseDate.split("-")[2])+"/"+(song.releaseDate.split("-")[1])+"/"+(song.releaseDate.split("-").first())
 }
 
-private fun releaseDatePrecisionMonth(): String {
-    return "TODO"
+private fun releaseDatePrecisionMonth(song: Song): String {
+    return DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]+", "+(song.releaseDate.split("-").first())
 }
 
 private fun releaseDatePrecisionYear(song: Song): String {

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -28,7 +28,7 @@ private fun getReleaseDatePrecisionDay(releaseDate: String): String {
 
 private fun getReleaseDatePrecisionMonth(releaseDate: String): String {
     val separator = ","
-    val month = DateFormatSymbols().getMonths()[((releaseDate.split("-")[1])).toInt()]
+    val month = DateFormatSymbols().months[((releaseDate.split("-")[1])).toInt()]
     val year = (releaseDate.split("-")[0])
     return "$month$separator $year"
 

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -1,0 +1,26 @@
+package ayds.newyork.songinfo.home.view
+
+import ayds.newyork.songinfo.home.model.entities.Song
+
+interface ReleaseDateMapper {
+    fun ReleaseDatePrecision(song: Song): String
+}
+
+internal class ReleaseDateMapperImpl : ReleaseDateMapper {
+    override fun ReleaseDatePrecision(song: Song): String {
+        return "TODO"
+    }
+
+    private fun ReleaseDatePrecisionDay(): String {
+        return "TODO"
+    }
+
+    private fun ReleaseDatePrecisionMonth(): String {
+        return "TODO"
+    }
+
+    private fun ReleaseDatePrecisionYear(): String {
+        return "TODO"
+    }
+
+}

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -18,15 +18,20 @@ internal class ReleaseDateMapperImpl : ReleaseDateMapper {
 }
 
 private fun releaseDatePrecisionDay(song: Song): String {
-    return (song.releaseDate.split("-")[2]) + "/" + (song.releaseDate.split("-")[1]) + "/" + (song.releaseDate.split(
-        "-"
-    ).first())
+    val separator = "/";
+    var day = song.releaseDate.split("-")[2]
+    var month = song.releaseDate.split("-")[1]
+    var year = song.releaseDate.split("-")[0]
+
+    return "$day$separator$month$separator$year"
 }
 
 private fun releaseDatePrecisionMonth(song: Song): String {
-    return DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()] + ", " + (song.releaseDate.split(
-        "-"
-    ).first())
+    val separator = ",";
+    var month = DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]
+    var year = (song.releaseDate.split("-")[0]);
+    return "$month$separator $year";
+
 }
 
 private fun releaseDatePrecisionYear(song: Song): String {

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -18,19 +18,19 @@ internal class ReleaseDateMapperImpl : ReleaseDateMapper {
 }
 
 private fun releaseDatePrecisionDay(releaseDate: String): String {
-    val separator = "/";
-    var day = song.releaseDate.split("-")[2]
-    var month = song.releaseDate.split("-")[1]
-    var year = song.releaseDate.split("-")[0]
+    val separator = "/"
+    val day = releaseDate.split("-")[2]
+    val month = releaseDate.split("-")[1]
+    val year = releaseDate.split("-")[0]
 
     return "$day$separator$month$separator$year"
 }
 
 private fun releaseDatePrecisionMonth(releaseDate: String): String {
-    val separator = ",";
-    var month = DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]
-    var year = (song.releaseDate.split("-")[0]);
-    return "$month$separator $year";
+    val separator = ","
+    val month = DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]
+    val year = (releaseDate.split("-")[0])
+    return "$month$separator $year"
 
 }
 

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -19,9 +19,10 @@ internal class ReleaseDateMapperImpl : ReleaseDateMapper {
 
 private fun getReleaseDatePrecisionDay(releaseDate: String): String {
     val separator = "/"
-    val day = releaseDate.split("-")[2]
-    val month = releaseDate.split("-")[1]
-    val year = releaseDate.split("-")[0]
+    val releaseDateArray = releaseDate.split("-").toTypedArray()
+    val day = releaseDateArray[2]
+    val month = releaseDateArray[1]
+    val year = releaseDateArray[0]
 
     return "$day$separator$month$separator$year"
 }

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -1,5 +1,6 @@
 package ayds.newyork.songinfo.home.view
 
+import ayds.newyork.songinfo.home.model.entities.DatePrecision
 import ayds.newyork.songinfo.home.model.entities.Song
 import java.text.DateFormatSymbols
 
@@ -10,14 +11,13 @@ interface ReleaseDateMapper {
 internal class ReleaseDateMapperImpl : ReleaseDateMapper {
     override fun releaseDatePrecision(song: Song): String =
         when (song.releaseDatePrecision) {
-            "day" -> releaseDatePrecisionDay(song)
-            "month" -> releaseDatePrecisionMonth(song)
-            "year" -> releaseDatePrecisionYear(song)
-            else -> "error"
+            DatePrecision.DAY -> releaseDatePrecisionDay(song.releaseDate)
+            DatePrecision.MONTH -> releaseDatePrecisionMonth(song.releaseDate)
+            DatePrecision.YEAR -> releaseDatePrecisionYear(song.releaseDate)
         }
 }
 
-private fun releaseDatePrecisionDay(song: Song): String {
+private fun releaseDatePrecisionDay(releaseDate: String): String {
     val separator = "/";
     var day = song.releaseDate.split("-")[2]
     var month = song.releaseDate.split("-")[1]
@@ -26,7 +26,7 @@ private fun releaseDatePrecisionDay(song: Song): String {
     return "$day$separator$month$separator$year"
 }
 
-private fun releaseDatePrecisionMonth(song: Song): String {
+private fun releaseDatePrecisionMonth(releaseDate: String): String {
     val separator = ",";
     var month = DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]
     var year = (song.releaseDate.split("-")[0]);
@@ -34,7 +34,7 @@ private fun releaseDatePrecisionMonth(song: Song): String {
 
 }
 
-private fun releaseDatePrecisionYear(song: Song): String {
+private fun releaseDatePrecisionYear(releaseDate: String): String {
     return try {
         val year: Int = song.releaseDate.toInt()
         val leap = if (year.isALeapYear()) "a leap year" else "not a leap year"

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -28,7 +28,7 @@ private fun releaseDatePrecisionDay(releaseDate: String): String {
 
 private fun releaseDatePrecisionMonth(releaseDate: String): String {
     val separator = ","
-    val month = DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]
+    val month = DateFormatSymbols().getMonths()[((releaseDate.split("-")[1])).toInt()]
     val year = (releaseDate.split("-")[0])
     return "$month$separator $year"
 
@@ -36,7 +36,7 @@ private fun releaseDatePrecisionMonth(releaseDate: String): String {
 
 private fun releaseDatePrecisionYear(releaseDate: String): String {
     return try {
-        val year: Int = song.releaseDate.toInt()
+        val year: Int = releaseDate.toInt()
         val leap = if (year.isALeapYear()) "a leap year" else "not a leap year"
 
         "$year $leap"

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -5,19 +5,19 @@ import ayds.newyork.songinfo.home.model.entities.Song
 import java.text.DateFormatSymbols
 
 interface ReleaseDateMapper {
-    fun releaseDatePrecision(song: Song): String
+    fun getReleaseDatePrecision(song: Song): String
 }
 
 internal class ReleaseDateMapperImpl : ReleaseDateMapper {
-    override fun releaseDatePrecision(song: Song): String =
+    override fun getReleaseDatePrecision(song: Song): String =
         when (song.releaseDatePrecision) {
-            DatePrecision.DAY -> releaseDatePrecisionDay(song.releaseDate)
-            DatePrecision.MONTH -> releaseDatePrecisionMonth(song.releaseDate)
-            DatePrecision.YEAR -> releaseDatePrecisionYear(song.releaseDate)
+            DatePrecision.DAY -> getReleaseDatePrecisionDay(song.releaseDate)
+            DatePrecision.MONTH -> getReleaseDatePrecisionMonth(song.releaseDate)
+            DatePrecision.YEAR -> getReleaseDatePrecisionYear(song.releaseDate)
         }
 }
 
-private fun releaseDatePrecisionDay(releaseDate: String): String {
+private fun getReleaseDatePrecisionDay(releaseDate: String): String {
     val separator = "/"
     val day = releaseDate.split("-")[2]
     val month = releaseDate.split("-")[1]
@@ -26,7 +26,7 @@ private fun releaseDatePrecisionDay(releaseDate: String): String {
     return "$day$separator$month$separator$year"
 }
 
-private fun releaseDatePrecisionMonth(releaseDate: String): String {
+private fun getReleaseDatePrecisionMonth(releaseDate: String): String {
     val separator = ","
     val month = DateFormatSymbols().getMonths()[((releaseDate.split("-")[1])).toInt()]
     val year = (releaseDate.split("-")[0])
@@ -34,7 +34,7 @@ private fun releaseDatePrecisionMonth(releaseDate: String): String {
 
 }
 
-private fun releaseDatePrecisionYear(releaseDate: String): String {
+private fun getReleaseDatePrecisionYear(releaseDate: String): String {
     return try {
         val year: Int = releaseDate.toInt()
         val leap = if (year.isALeapYear()) "a leap year" else "not a leap year"

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/ReleaseDateMapper.kt
@@ -7,20 +7,23 @@ interface ReleaseDateMapper {
 }
 
 internal class ReleaseDateMapperImpl : ReleaseDateMapper {
-    override fun ReleaseDatePrecision(song: Song): String {
-        return "TODO"
-    }
+    override fun ReleaseDatePrecision(song: Song): String =
+        when (song.releaseDatePrecision) {
+            "day" -> ReleaseDatePrecisionDay()
+            "month" -> ReleaseDatePrecisionMonth()
+            "year" -> ReleaseDatePrecisionYear()
+            else -> "error"
+        }
+}
 
-    private fun ReleaseDatePrecisionDay(): String {
-        return "TODO"
-    }
+private fun ReleaseDatePrecisionDay(): String {
+    return "TODO"
+}
 
-    private fun ReleaseDatePrecisionMonth(): String {
-        return "TODO"
-    }
+private fun ReleaseDatePrecisionMonth(): String {
+    return "TODO"
+}
 
-    private fun ReleaseDatePrecisionYear(): String {
-        return "TODO"
-    }
-
+private fun ReleaseDatePrecisionYear(): String {
+    return "TODO"
 }

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
@@ -8,13 +8,12 @@ import java.text.DateFormatSymbols
 
 interface SongDescriptionHelper {
     fun getSongDescriptionText(song: Song = EmptySong): String
-    fun getReleaseDateDescription(song: Song = EmptySong): String
 }
 
 internal class SongDescriptionHelperImpl(releaseDateMapper: ReleaseDateMapper) :
     SongDescriptionHelper {
-    override fun getReleaseDateDescription(song: Song): String {
-        return releaseDateMapper.releaseDatePrecision(song)
+    private fun getReleaseDateDescription(song: Song): String {
+        return releaseDateMapper.getReleaseDatePrecision(song)
     }
 
     override fun getSongDescriptionText(song: Song): String {

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
@@ -12,9 +12,6 @@ interface SongDescriptionHelper {
 
 internal class SongDescriptionHelperImpl(releaseDateMapper: ReleaseDateMapper) :
     SongDescriptionHelper {
-    private fun getReleaseDateDescription(song: Song): String {
-        return releaseDateMapper.getReleaseDatePrecision(song)
-    }
 
     override fun getSongDescriptionText(song: Song): String {
         return when (song) {

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
@@ -3,6 +3,7 @@ package ayds.newyork.songinfo.home.view
 import ayds.newyork.songinfo.home.model.entities.EmptySong
 import ayds.newyork.songinfo.home.model.entities.Song
 import ayds.newyork.songinfo.home.model.entities.SpotifySong
+import ayds.newyork.songinfo.home.view.HomeViewInjector.releaseDateMapper
 import java.text.DateFormatSymbols
 
 interface SongDescriptionHelper {
@@ -12,15 +13,7 @@ interface SongDescriptionHelper {
 
 internal class SongDescriptionHelperImpl (releaseDateMapper: ReleaseDateMapper): SongDescriptionHelper {
     override fun getReleaseDateDescription(song: Song): String {
-        var releaseDateDescription=""
-        releaseDateDescription = if (song.releaseDatePrecision=="year"){
-            (song.releaseDate.split("-").first())
-        } else if (song.releaseDatePrecision=="month"){
-            DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]+","+(song.releaseDate.split("-").first())
-        } else{
-            (song.releaseDate.split("-")[2])+"/"+(song.releaseDate.split("-")[1])+"/"+(song.releaseDate.split("-").first())
-        }
-        return releaseDateDescription
+        return releaseDateMapper.releaseDatePrecision(song)
     }
 
     override fun getSongDescriptionText(song: Song): String {

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
@@ -8,10 +8,11 @@ import java.text.DateFormatSymbols
 
 interface SongDescriptionHelper {
     fun getSongDescriptionText(song: Song = EmptySong): String
-    fun getReleaseDateDescription(song:Song =EmptySong): String
+    fun getReleaseDateDescription(song: Song = EmptySong): String
 }
 
-internal class SongDescriptionHelperImpl (releaseDateMapper: ReleaseDateMapper): SongDescriptionHelper {
+internal class SongDescriptionHelperImpl(releaseDateMapper: ReleaseDateMapper) :
+    SongDescriptionHelper {
     override fun getReleaseDateDescription(song: Song): String {
         return releaseDateMapper.releaseDatePrecision(song)
     }

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
@@ -25,7 +25,7 @@ internal class SongDescriptionHelperImpl(releaseDateMapper: ReleaseDateMapper) :
                 }\n" +
                         "Artist: ${song.artistName}\n" +
                         "Album: ${song.albumName}\n" +
-                        "ReleaseDate: ${getReleaseDateDescription(song)}"
+                        "ReleaseDate: ${releaseDateMapper.getReleaseDatePrecision(song)}"
             else -> "Song not found"
         }
     }

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
@@ -10,7 +10,7 @@ interface SongDescriptionHelper {
     fun getReleaseDateDescription(song:Song =EmptySong): String
 }
 
-internal class SongDescriptionHelperImpl : SongDescriptionHelper {
+internal class SongDescriptionHelperImpl (releaseDateMapper: ReleaseDateMapper): SongDescriptionHelper {
     override fun getReleaseDateDescription(song: Song): String {
         var releaseDateDescription=""
         releaseDateDescription = if (song.releaseDatePrecision=="year"){

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
@@ -3,12 +3,26 @@ package ayds.newyork.songinfo.home.view
 import ayds.newyork.songinfo.home.model.entities.EmptySong
 import ayds.newyork.songinfo.home.model.entities.Song
 import ayds.newyork.songinfo.home.model.entities.SpotifySong
+import java.text.DateFormatSymbols
 
 interface SongDescriptionHelper {
     fun getSongDescriptionText(song: Song = EmptySong): String
+    fun getReleaseDateDescription(song:Song =EmptySong): String
 }
 
 internal class SongDescriptionHelperImpl : SongDescriptionHelper {
+    override fun getReleaseDateDescription(song: Song): String {
+        var releaseDateDescription=""
+        releaseDateDescription = if (song.releaseDatePrecision=="year"){
+            (song.releaseDate.split("-").first())
+        } else if (song.releaseDatePrecision=="month"){
+            DateFormatSymbols().getMonths()[((song.releaseDate.split("-")[1])).toInt()]+","+(song.releaseDate.split("-").first())
+        } else{
+            (song.releaseDate.split("-")[2])+"/"+(song.releaseDate.split("-")[1])+"/"+(song.releaseDate.split("-").first())
+        }
+        return releaseDateDescription
+    }
+
     override fun getSongDescriptionText(song: Song): String {
         return when (song) {
             is SpotifySong ->
@@ -18,8 +32,9 @@ internal class SongDescriptionHelperImpl : SongDescriptionHelper {
                 }\n" +
                         "Artist: ${song.artistName}\n" +
                         "Album: ${song.albumName}\n" +
-                        "Year: ${song.year}"
+                        "ReleaseDate: ${getReleaseDateDescription(song)}"
             else -> "Song not found"
         }
     }
+
 }

--- a/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
+++ b/app/src/main/java/ayds/newyork/songinfo/home/view/SongDescriptionHelperImpl.kt
@@ -3,14 +3,12 @@ package ayds.newyork.songinfo.home.view
 import ayds.newyork.songinfo.home.model.entities.EmptySong
 import ayds.newyork.songinfo.home.model.entities.Song
 import ayds.newyork.songinfo.home.model.entities.SpotifySong
-import ayds.newyork.songinfo.home.view.HomeViewInjector.releaseDateMapper
-import java.text.DateFormatSymbols
 
 interface SongDescriptionHelper {
     fun getSongDescriptionText(song: Song = EmptySong): String
 }
 
-internal class SongDescriptionHelperImpl(releaseDateMapper: ReleaseDateMapper) :
+internal class SongDescriptionHelperImpl(private val releaseDateMapper: ReleaseDateMapper) :
     SongDescriptionHelper {
 
     override fun getSongDescriptionText(song: Song): String {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip

--- a/observer/build.gradle
+++ b/observer/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 compileKotlin {


### PR DESCRIPTION
Se elimina la propiedad year de SpotifySong.
Se agrega un Release-date-precision al modelo y la base de datos.
Se modifica la descripcion de una cancion de acuerdo al release-date-precision.
Se utiliza ReleaseDateMaper para determinar el tipo de descripcion de la cancion segun su fecha.